### PR TITLE
Update to use the serverless AWS Provider/Credentials.

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -5,8 +5,13 @@ const S3_PREFIX = 'arn:aws:s3:::'
 const TAG = 'SLS-S3-REPLICATION-PLUGIN'
 const LOG_PREFIX = 'SLS-S3-REPLICATION-PLUGIN:'
 
-async function getAccountId () {
-  const sts = new aws.STS()
+function getCredentials(serverless) {
+  const provider = serverless.getProvider("aws");
+  return Object.assign({}, provider.getCredentials(), { region: provider.region });
+}
+
+async function getAccountId (serverless) {
+  const sts = new aws.STS(getCredentials(serverless))
   const identity = await sts.getCallerIdentity().promise()
   return identity.Account
 }
@@ -99,7 +104,7 @@ async function createOrUpdateS3ReplicationRole (
   targetBucketConfigs,
   sourceRegion
 ) {
-  const iam = new aws.IAM()
+  const iam = new aws.IAM(getCredentials(serverless))
 
   const roleName = `${getServiceName(serverless)}-${sourceRegion}-s3-rep-role`
 
@@ -184,14 +189,14 @@ function getAssumeRolePolicyDocument () {
 }
 
 async function putBucketReplicationsForReplicationConfigMap (serverless, replicationConfigMap) {
-  const s3 = new aws.S3()
+  const s3 = new aws.S3(getCredentials(serverless))
 
   for (const sourceBucket of replicationConfigMap.keys()) {
     const sourceReplicationConfig = replicationConfigMap.get(sourceBucket)
     const s3BucketReplicationRequest = {
       Bucket: sourceBucket,
       ReplicationConfiguration: {
-        Role: `arn:aws:iam::${await getAccountId()}:role/${sourceReplicationConfig.role}`,
+        Role: `arn:aws:iam::${await getAccountId(serverless)}:role/${sourceReplicationConfig.role}`,
         Rules: sourceReplicationConfig.rules
       }
     }
@@ -262,17 +267,17 @@ async function allSpecifiedBucketsExist (serverless) {
 }
 
 async function validateBucketExists (serverless, bucketName) {
-  const s3 = new aws.S3()
+  const s3 = new aws.S3(getCredentials(serverless))
 
   try {
     await s3
       .headBucket({
         Bucket: bucketName,
-        ExpectedBucketOwner: `${await getAccountId()}`
+        ExpectedBucketOwner: `${await getAccountId(serverless)}`
       })
       .promise()
   } catch (e) {
-    if (e.code === 'NotFound') {
+    if (e.code === 'NotFound' || e.code === "BadRequest") {
       serverless.cli.log(`${LOG_PREFIX} ${chalk.red(`Bucket ${bucketName} does not exist yet. Plugin will only be executed when all buckets exist`)}`)
 
       return false


### PR DESCRIPTION
Tested with `Serverless 2.64.1`

The plugin fails unless the `AWS_PROFILE` env var is set. It doesn't use the configured serverless provider's profile.  

Updated each AWS SDK service calls to use the credentials extracted from the AWS provider in the serverless config. This allows the plugin to use the `profile` attribute.

Also update bucket validation to check for `BadRequest`. A BadRequest code will be returned if the bucket once existed on your account but it's been deleted. This is the same state as `NotFound`, as it wasn't found (but existed at one time).

### To Test Bad Credentials:

[with current code]
* Make sure env var `AWS_PROFILE` (or explicit secret/keys) are not set
* Deploy
_Expected_: **Fails w/ Bad Credentials call**

[with pr code]
* Make sure env var `AWS_PROFILE` (or explicit secret/keys) are not set
* Make sure your serverless `provider.profile` is setup in your `~/.aws/credentials` config
* Deploy
_Expected_: **Succeed w/correct credentials from your `profile`**

### To Test BadRequest:

[with current code]
* Create and then delete a bucket in one of your regions
* Use existing plugin and deploy.  
_Expected_:  **Get a `BadRequest` response + thrown error**

[with pr code]
* Deploy
_Expected_: **Get a message that bucket doesn't exist and returns w/o throwing exception**