### PR TITLE
Allow overriding of the IAM S3 Replication Role prefix to overcome long service and s3 bucket names

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,3 +63,30 @@ custom:
       - eu-central-1: my-bucket-jlsadjklsd-eu-central-1
       - us-east-1: my-bucket-jlsadjklsd-us-east-1
 ```
+
+## Overriding the S3 Replication Role name
+The default value of the Replication Role is: `${serviceName}-${sourceRegion}-${sourceBucket}-s3-rep-role`. 
+In most cases this default value will work without issue. But if your `serviceName` or `sourceBucket` are long, the cloudformation stack will fail with an error similar to:
+
+```
+Error:
+ValidationError: 1 validation error detected: Value 'your-long-service-name-eu-west-1-your-long-s3-bucket-name-s3-rep-role' at 'roleName' failed to satisfy constraint: Member must have length less than or equal to 64
+```
+
+To resolve this issue, you can use the `replicationRolePrefixOverride` configuration to set a default prefix value, which will use the following format: `${replicationRolePrefixOverride}-${sourceRegion}-s3-rep-role`.
+
+```yaml
+custom:
+  s3ReplicationPlugin:
+    singleDirectionReplication:
+      - sourceBucket:
+          eu-west-1: my-bucket-jlsadjklsd-eu-west-1
+        targetBuckets:
+          - eu-west-2: my-bucket-jlsadjklsd-eu-west-2
+          - eu-west-1: my-bucket-jlsadjklsd-sec-eu-west-1
+    replicationRolePrefixOverride: "my-prefix"
+```
+
+This will result in the following replication role names:
+- `my-prefix-eu-west-1-s3-rep-role`
+- `my-prefix-eu-west-2-s3-rep-role`

--- a/src/helper.js
+++ b/src/helper.js
@@ -4,6 +4,7 @@ const aws = require('aws-sdk')
 const S3_PREFIX = 'arn:aws:s3:::'
 const TAG = 'SLS-S3-REPLICATION-PLUGIN'
 const LOG_PREFIX = 'SLS-S3-REPLICATION-PLUGIN:'
+const REPLICATION_ROLE_SUFFIX = "s3-rep-role";
 
 function getCredentials (serverless) {
   const provider = serverless.getProvider('aws')
@@ -106,8 +107,10 @@ async function createOrUpdateS3ReplicationRole (
 ) {
   const iam = new aws.IAM(getCredentials(serverless))
 
-  const roleName = `${getServiceName(serverless)}-${sourceRegion}-${sourceBucket}-s3-rep-role`
-
+  const defaultRoleName = `${getServiceName(serverless)}-${sourceRegion}-${sourceBucket}-${REPLICATION_ROLE_SUFFIX}`
+  const prefixOverride = serverless.service.custom.s3ReplicationPlugin.replicationRolePrefixOverride
+  const roleName = prefixOverride ? `${prefixOverride}-${sourceRegion}-${REPLICATION_ROLE_SUFFIX}` : defaultRoleName
+  
   const createRoleRequest = {
     RoleName: roleName,
     AssumeRolePolicyDocument: getAssumeRolePolicyDocument(),

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,8 @@ class S3ReplicationPlugin {
           type: 'object',
           properties: {
             singleDirectionReplication: { type: 'array' },
-            bidirectionalReplicationBuckets: { type: 'array' }
+            bidirectionalReplicationBuckets: { type: 'array' },
+            replicationRolePrefixOverride: { type: 'string' },
           }
         }
       },

--- a/tests/helper.test.js
+++ b/tests/helper.test.js
@@ -378,7 +378,17 @@ test('test hybrid model of single direction and bidirectional s3 replication', a
   })
 })
 
-function createServerlessContext (singleDirection, bidirectional) {
+test('test replication role with prefix override', async () => {
+  const prefix = "my-prefix"
+  const replicationConfigMap = await helper.setupS3Replication(createServerlessContext(true, false, prefix))
+
+  expect(replicationConfigMap.size).toBe(2)
+
+  expect(replicationConfigMap.get('my-bucket-eu-west-1').role).toEqual(`${prefix}-eu-west-1-s3-rep-role`);
+  expect(replicationConfigMap.get('my-bucket-eu-central-1').role).toEqual(`${prefix}-eu-central-1-s3-rep-role`);
+});
+
+function createServerlessContext (singleDirection, bidirectional, replicationRolePrefixOverride) {
   return {
     service: {
       provider: {
@@ -388,7 +398,8 @@ function createServerlessContext (singleDirection, bidirectional) {
       custom: {
         s3ReplicationPlugin: {
           singleDirectionReplication: singleDirection ? createSingleDirectionReplicationConfig() : undefined,
-          bidirectionalReplicationBuckets: bidirectional ? createBidirectionalReplicationConfig() : undefined
+          bidirectionalReplicationBuckets: bidirectional ? createBidirectionalReplicationConfig() : undefined,
+          replicationRolePrefixOverride
         }
       }
     },


### PR DESCRIPTION
This is to address the change to the iam replication role as part of release 1.0.3.

With descriptive service names and/or descriptive bucket names (which need to be globally unique) the total character length will easily exceed 64-chars, causing a failure during cloudformation stack verification.

This change allows the user to explicitly override the prefix of the role name while still appending the `sourceRegion` and the `s3-rep-role` suffix.

Unit test added to verify the prefix override, if available, is used.