### PR TITLE
Feat - short static role name

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -106,7 +106,7 @@ async function createOrUpdateS3ReplicationRole (
 ) {
   const iam = new aws.IAM(getCredentials(serverless))
 
-  const roleName = `${getServiceName(serverless)}-${sourceRegion}-${sourceBucket}-s3-rep-role`
+  const roleName = 'assume-role-for-s3-replication'
 
   const createRoleRequest = {
     RoleName: roleName,

--- a/tests/helper.test.js
+++ b/tests/helper.test.js
@@ -44,7 +44,7 @@ test('test single direction s3 replication', async () => {
 
   expect(replicationConfigMap.get('my-bucket-eu-west-1')).toEqual({
     region: 'eu-west-1',
-    role: 'TEST-SERVICE-eu-west-1-my-bucket-eu-west-1-s3-rep-role',
+    role: 'assume-role-for-s3-replication',
     rules: [
       {
         DeleteMarkerReplication: {
@@ -81,7 +81,7 @@ test('test single direction s3 replication', async () => {
 
   expect(replicationConfigMap.get('my-bucket-eu-central-1')).toEqual({
     region: 'eu-central-1',
-    role: 'TEST-SERVICE-eu-central-1-my-bucket-eu-central-1-s3-rep-role',
+    role: 'assume-role-for-s3-replication',
     rules: [
       {
         DeleteMarkerReplication: {
@@ -110,7 +110,7 @@ test('test bidirectional s3 replication', async () => {
 
   expect(replicationConfigMap.get('my-bucket-eu-west-1')).toEqual({
     region: 'eu-west-1',
-    role: 'TEST-SERVICE-eu-west-1-my-bucket-eu-west-1-s3-rep-role',
+    role: 'assume-role-for-s3-replication',
     rules: [
       {
         DeleteMarkerReplication: {
@@ -147,7 +147,7 @@ test('test bidirectional s3 replication', async () => {
 
   expect(replicationConfigMap.get('my-bucket-eu-central-1')).toEqual({
     region: 'eu-central-1',
-    role: 'TEST-SERVICE-eu-central-1-my-bucket-eu-central-1-s3-rep-role',
+    role: 'assume-role-for-s3-replication',
     rules: [
       {
         DeleteMarkerReplication: {
@@ -184,7 +184,7 @@ test('test bidirectional s3 replication', async () => {
 
   expect(replicationConfigMap.get('my-bucket-us-east-1')).toEqual({
     region: 'us-east-1',
-    role: 'TEST-SERVICE-us-east-1-my-bucket-us-east-1-s3-rep-role',
+    role: 'assume-role-for-s3-replication',
     rules: [
       {
         DeleteMarkerReplication: {
@@ -226,7 +226,7 @@ test('test hybrid model of single direction and bidirectional s3 replication', a
   expect(replicationConfigMap.size).toBe(3)
   expect(replicationConfigMap.get('my-bucket-eu-west-1')).toEqual({
     region: 'eu-west-1',
-    role: 'TEST-SERVICE-eu-west-1-my-bucket-eu-west-1-s3-rep-role',
+    role: 'assume-role-for-s3-replication',
     rules: [
       {
         DeleteMarkerReplication: {
@@ -291,7 +291,7 @@ test('test hybrid model of single direction and bidirectional s3 replication', a
 
   expect(replicationConfigMap.get('my-bucket-eu-central-1')).toEqual({
     region: 'eu-central-1',
-    role: 'TEST-SERVICE-eu-central-1-my-bucket-eu-central-1-s3-rep-role',
+    role: 'assume-role-for-s3-replication',
     rules: [
       {
         DeleteMarkerReplication: {
@@ -342,7 +342,7 @@ test('test hybrid model of single direction and bidirectional s3 replication', a
 
   expect(replicationConfigMap.get('my-bucket-us-east-1')).toEqual({
     region: 'us-east-1',
-    role: 'TEST-SERVICE-us-east-1-my-bucket-us-east-1-s3-rep-role',
+    role: 'assume-role-for-s3-replication',
     rules: [
       {
         DeleteMarkerReplication: {


### PR DESCRIPTION
Use a shorter role name as we surpass the limit of AWS - more than 64 characters.

Use a static role name as it it just allows to assume role, the policy which is created later is per bucket.